### PR TITLE
Fix closure type annotation in hairlines.js

### DIFF
--- a/src/extras/hairlines.js
+++ b/src/extras/hairlines.js
@@ -30,7 +30,7 @@ Dygraph.Plugins.Hairlines = (function() {
 var CLICK_DELAY_MS = 300;
 
 var hairlines = function(opt_options) {
-  /* @type {!Array.<!Hairline>} */
+  /** @private {!Array.<!Hairline>} */
   this.hairlines_ = [];
 
   // Used to detect resizes (which require the divs to be repositioned).


### PR DESCRIPTION
Closure type annotations require two stars, and private members (which have a traling underscore) should be marked as such.

Please read the guide to making dygraphs changes:
http://dygraphs.com/changes.html

Pull Requests will only be accepted if:

- You clearly explain what you're adding and why you believe it's an
  improvement. For example: "Fixes issue #123".
- You adhere to the style of the rest of the dygraphs code base.
- You write an `auto_test` for the code that you're adding.

Be sure to document any new options you add. Also be aware that PRs which add
options are likely to be rejected. dygraphs already has many options. If you
can fit your feature into one of those or implement it as a plugin, it will be
more likely to get merged.
